### PR TITLE
ViewHolder적용. addlist+getView 호출시 셧다운 되던 문제점 해결

### DIFF
--- a/ToDoApp/app/src/main/java/com/chanmin/todoapp/ListAdapter.java
+++ b/ToDoApp/app/src/main/java/com/chanmin/todoapp/ListAdapter.java
@@ -43,22 +43,24 @@ class ListAdapter extends BaseAdapter {
     }
 
     public View getView(int position, View convertView, ViewGroup parent) {
+        ViewHolder viewHolder;
         if (convertView == null) {
             convertView = inflater.inflate(layout, parent, false);
+
+            viewHolder = new ViewHolder();
+            viewHolder.title = (TextView) convertView.findViewById(R.id.listTitle);
+            viewHolder.check = (CheckBox) convertView.findViewById(R.id.checkBox);
+            viewHolder.title.setTag(position);
+            viewHolder.check.setTag(position);
+            convertView.setTag(viewHolder);
+        }else{
+            viewHolder = (ViewHolder) convertView.getTag();
         }
-        TextView text = (TextView) convertView.findViewById(R.id.listTitle);
-        text.setTag(position);
-        text.setText(getItem(position).getTitle());
-        text.setTextColor(Color.parseColor(getItem(position).getColor()));
-        CheckBox checkBox = (CheckBox) convertView.findViewById(R.id.checkBox);
-        checkBox.setTag(position);
-        checkBox.setChecked(false);
-        if (deleteItem[position] != null) {
-            if (deleteItem[position]) {
-                checkBox.setChecked(true);
-            }
-        } else {
-            Log.i("DeleteItemError", "position : " + position + " //Error");
+        viewHolder.title.setText(getItem(position).getTitle());
+        viewHolder.title.setTextColor(Color.parseColor(getItem(position).getColor()));
+        viewHolder.check.setChecked(false);
+        if (deleteItem[position]) {
+            viewHolder.check.setChecked(true);
         }
         return convertView;
     }

--- a/ToDoApp/app/src/main/java/com/chanmin/todoapp/ToDoMainActivity.java
+++ b/ToDoApp/app/src/main/java/com/chanmin/todoapp/ToDoMainActivity.java
@@ -65,7 +65,6 @@ public class ToDoMainActivity extends AppCompatActivity {
         for (int i = 0; i < deleteItem.length; i++) {
             deleteItem[i] = false;
         }
-
         list.clearChoices();
         adapter.notifyDataSetChanged();
     }
@@ -136,7 +135,8 @@ public class ToDoMainActivity extends AppCompatActivity {
                     }
                     break;
             }
-            adapter.notifyDataSetChanged();
+            adapter = new ListAdapter(this, R.layout.activity_list_view_item, listItem, deleteItem);
+            list.setAdapter(adapter);
             list.clearChoices();
         }
     }

--- a/ToDoApp/app/src/main/java/com/chanmin/todoapp/ViewHolder.java
+++ b/ToDoApp/app/src/main/java/com/chanmin/todoapp/ViewHolder.java
@@ -1,0 +1,13 @@
+package com.chanmin.todoapp;
+
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+/**
+ * Created by Administrator on 2017-01-18.
+ */
+
+public class ViewHolder {
+    public TextView title;
+    public CheckBox check;
+}


### PR DESCRIPTION
viewHolder를 적용해서 매번 getView가 findViewById를 호출하던 것을 최적화시킴. 어떠한 변경점이 없을 경우에는 뷰 재사용.
deleteItem의 배열갯수가 변할때, listAdapter클래스에 이를 반영해 주도록 변경.
